### PR TITLE
#34: Always Today's Date selected for Photo Journal

### DIFF
--- a/lib/plants/my_plants_photo_journal_page.dart
+++ b/lib/plants/my_plants_photo_journal_page.dart
@@ -107,6 +107,8 @@ class _PhotoJournalPageState extends State<PhotoJournalPage> {
     final isDarkMode = Theme.of(context).brightness == Brightness.dark;
     String? imageUrl = "";
 
+    _edtDateController.text = DateFormat('yyyy-MM-dd').format(DateTime.now());
+
     await showDialog(
       context: context,
       builder: (BuildContext context) {
@@ -130,7 +132,10 @@ class _PhotoJournalPageState extends State<PhotoJournalPage> {
 
                   // Date Field
                   GestureDetector(
-                    onTap: () => _selectDate(context),
+                    onTap: () async {
+                      await _selectDate(context);
+                      setDialogState(() {});
+                    },
                     child: AbsorbPointer(
                       child: TextField(
                         controller: _edtDateController,


### PR DESCRIPTION
- when you want to add a new photo, inside the popup there is a date picker, the date picker was before the changes empty, now today's date is selected automatically

- after you added a photo for another date (not today) and you want to add another photo then the date of the last added photo was automatically picked, now always today's date is picked