### PR TITLE
Add water reminder bubble above water button ✨ 

### DIFF
--- a/lib/pages/my_plants_pages/my_plants_details_page.dart
+++ b/lib/pages/my_plants_pages/my_plants_details_page.dart
@@ -306,15 +306,42 @@ class _MyPlantsDetailsPage extends State<MyPlantsDetailsPage> {
         ),
         Row(
           children: [
-            IconButton(
-              icon: Icon(Icons.water_drop,
-                  color: _showPlantNeedsToBeWateredTodayButWasNotYet
-                      ? Colors.orange
-                      : Colors.grey),
-              onPressed: () {
-                plantWasWateredToday();
-              },
-            ),
+            Stack(
+              alignment: Alignment.center,
+              clipBehavior: Clip.none,
+              children: [
+                IconButton(
+                  icon: Icon(Icons.water_drop,
+                      color: _showPlantNeedsToBeWateredTodayButWasNotYet
+                          ? Colors.orange
+                          : Colors.grey),
+                  onPressed: () {
+                    plantWasWateredToday();
+                  },
+                ),
+                if (_showPlantNeedsToBeWateredTodayButWasNotYet)
+                  Positioned(
+                    top: -20,
+                    right: -15,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.orange,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Text(
+                        "Water me!",
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            )
+            ,
             IconButton(
               icon: const Icon(Icons.settings),
               onPressed: () async {


### PR DESCRIPTION
Added a small info bubble above the water button when the plant needs to be watered today. The bubble displays "Water me!" in an orange box for better visibility, instead of just changing the button color. It appears only if the plant hasn't been watered yet. 🌱💧
![WhatsApp Image 2025-02-12 at 16 26 45 (1)](https://github.com/user-attachments/assets/2daf2e24-7f63-4025-ae22-3b65ea0bcea0)
![WhatsApp Image 2025-02-12 at 16 26 45](https://github.com/user-attachments/assets/68a904fb-8c0a-423b-b30a-89db23e39c4d)
